### PR TITLE
Add release notes and skip SSLv3 tests that can't work with httpbin.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,12 @@ alsoo be installed (in particular, nose), e.g.,
     pip install -e <path-to-https-shim>[test_support]
 
 
+Releases
+========
+
+* 0.10.1 (in progress)
+  * adding support for Python 2.7
+    * this library may not be necessary as of Python 2.7.9
+    * tests require Python >= 2.7
+* 0.10.0 (2013/12/19)
+  * initial release with support for Python <= 2.6

--- a/https_shim/__init__.py
+++ b/https_shim/__init__.py
@@ -19,7 +19,7 @@ class HTTPSConnection(httplib.HTTPSConnection):
         The same parameters as in httplib.HTTPSConnection, with the addition
         of ssl_version: One of the SSL PROTOCOL versions defined in the
         ssl module (PROTOCOL_SSLV2, PROTOCOL_SSLv23, etc. Note the
-        security warnings: SSL version 2 is insecure!
+        security warnings: SSL versions 2 and 3 are insecure!
         """
         if len(args) > 4:
             self.ssl_version = args[4]

--- a/https_shim/tests/tests.py
+++ b/https_shim/tests/tests.py
@@ -7,7 +7,6 @@ import urlparse
 from https_shim import HTTPSConnection
 from mock import Mock, patch
 
-HOSTNAME = "entdir.utexas.edu"
 
 class ConnectionError(RuntimeError):
     pass
@@ -187,6 +186,7 @@ class LookupTests(unittest.TestCase):
                                   ssl_version=ssl.PROTOCOL_SSLv23)
         self.assertEqual(0, len(errors))
 
+    @unittest.skip('httpbin.org turned off SSLv3 support')
     def test_can_get_using_SSLv3_connect_request(self):
         errors = self._connect_with_request(path='/get', method='GET',
                                   ssl_version=ssl.PROTOCOL_SSLv3)
@@ -205,6 +205,7 @@ class LookupTests(unittest.TestCase):
         errors = self._connect_with_request(ssl_version=ssl.PROTOCOL_SSLv23)
         self.assertEqual(0, len(errors))
 
+    @unittest.skip('httpbin.org turned off SSLv3 support')
     def test_can_post_using_SSLv3_connect_request(self):
         errors = self._connect_with_request(ssl_version=ssl.PROTOCOL_SSLv3)
         self.assertEqual(0, len(errors))
@@ -222,6 +223,7 @@ class LookupTests(unittest.TestCase):
                                   ssl_version=ssl.PROTOCOL_SSLv23)
         self.assertEqual(0, len(errors))
 
+    @unittest.skip('httpbin.org turned off SSLv3 support')
     def test_can_get_using_SSLv3_connect_full(self):
         errors = self._connect_full(path='/get', method='GET',
                                   ssl_version=ssl.PROTOCOL_SSLv3)
@@ -240,6 +242,7 @@ class LookupTests(unittest.TestCase):
         errors = self._connect_full(ssl_version=ssl.PROTOCOL_SSLv23)
         self.assertEqual(0, len(errors))
 
+    @unittest.skip('httpbin.org turned off SSLv3 support')
     def test_can_post_using_SSLv3_connect_full(self):
         errors = self._connect_full(ssl_version=ssl.PROTOCOL_SSLv3)
         self.assertEqual(0, len(errors))


### PR DESCRIPTION
We may not get Python 2.7.9 for some time, so I think it would be worth it to release a new tag in the meantime. When we do update to Python 2.7.9, this code should still work, but we may be able to stop using it all together.